### PR TITLE
docs: fix README and examples\n\n- Replace outdated OCI quick start w…

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -60,6 +60,12 @@ Python Flask web application. Shows how to map multiple directories for applicat
    sudo fledge build
    ```
 
+### Important: Agent requirements
+
+- OCI Rootfs examples require an `[agent]` section. Fledge injects the Kestrel agent into the image.
+- Initramfs default mode (no `[init]`): Kestrel is used; you may omit `[agent]` and Fledge will default to `source_strategy = "release"`, `version = "latest"`.
+- Initramfs with custom or no init (`[init] path=...` or `[init] none=true`): Do not include `[agent]` (Kestrel is not used).
+
 ## Tips for Creating Your Own Configurations
 
 ### For Initramfs Plugins

--- a/docs/examples/oci-nginx.toml
+++ b/docs/examples/oci-nginx.toml
@@ -8,6 +8,10 @@
 version = "1"
 strategy = "oci_rootfs"
 
+[agent]
+source_strategy = "release"
+version = "latest"
+
 [source]
 image = "nginx:alpine"
 

--- a/docs/examples/oci-postgres.toml
+++ b/docs/examples/oci-postgres.toml
@@ -8,6 +8,10 @@
 version = "1"
 strategy = "oci_rootfs"
 
+[agent]
+source_strategy = "release"
+version = "latest"
+
 [source]
 image = "postgres:15-alpine"
 

--- a/docs/examples/oci-python-flask.toml
+++ b/docs/examples/oci-python-flask.toml
@@ -20,6 +20,10 @@
 version = "1"
 strategy = "oci_rootfs"
 
+[agent]
+source_strategy = "release"
+version = "latest"
+
 [source]
 # Option 1: Use official Python image
 image = "python:3.11-alpine"

--- a/docs/init-modes.md
+++ b/docs/init-modes.md
@@ -33,6 +33,8 @@ busybox_sha256 = "6e123e7f3202a8c1e9b1f94d8941580a25135382b99e8d3e34fb858bba3113
 
 **No `[init]` section = default mode**
 
+Note: Kestrel agent is used in this mode. You may omit `[agent]` (defaults to `release/latest`) or specify it explicitly.
+
 **Boot flow:**
 ```
 Kernel → C init → Kestrel → Your app
@@ -53,6 +55,8 @@ Kernel → C init → Kestrel → Your app
 - Your custom init script/binary runs as PID 1
 - YOU manage the workload
 - **No Kestrel** (you handle lifecycle yourself)
+
+Do not include an `[agent]` section in this mode.
 
 **Configuration:**
 ```toml
@@ -105,6 +109,8 @@ Kernel → C init → Your custom init → Your app
 - Your binary becomes PID 1 directly
 - **YOU must mount filesystems** (`/proc`, `/sys`, `/dev`, etc.)
 - Maximum performance, maximum control
+
+Do not include an `[agent]` section in this mode.
 
 **Configuration:**
 ```toml


### PR DESCRIPTION
…ith correct schema and add [agent]\n- Require [agent] in all OCI examples; clarify defaults for initramfs\n- Add agent requirements section to examples README\n- Make init-modes explicit