### PR TITLE
feat: Dockerfile builds for oci_rootfs and initramfs; default Busybox…

### DIFF
--- a/cmd/fledge/main.go
+++ b/cmd/fledge/main.go
@@ -285,8 +285,8 @@ func buildOCIRootfs(ctx context.Context, cfg *config.Config, workDir, outputPath
 	logging.Info("Building OCI rootfs artifact")
 
 	// Validate OCI-specific requirements
-	if cfg.Source.Image == "" {
-		return fmt.Errorf("source.image is required for oci_rootfs strategy")
+	if cfg.Source.Image == "" && cfg.Source.Dockerfile == "" {
+		return fmt.Errorf("either source.image or source.dockerfile is required for oci_rootfs strategy")
 	}
 
 	// Create builder

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -201,10 +201,10 @@ type = "ext4"
 
 	_, err := Load(tmpFile)
 	if err == nil {
-		t.Fatal("expected error for missing image, got nil")
+		t.Fatal("expected error when neither image nor dockerfile provided, got nil")
 	}
-	if !strings.Contains(err.Error(), "source.image") {
-		t.Errorf("error should mention 'source.image', got: %v", err)
+	if !strings.Contains(err.Error(), "dockerfile") && !strings.Contains(err.Error(), "source.image") {
+		t.Errorf("error should mention 'source.image' or 'dockerfile', got: %v", err)
 	}
 }
 
@@ -234,7 +234,7 @@ type = "ntfs"
 }
 
 // TestValidationInitramfsMissingBusybox tests initramfs validation.
-func TestValidationInitramfsMissingBusybox(t *testing.T) {
+func TestInitramfsDefaultsBusyboxApplied(t *testing.T) {
 	content := `
 version = "1"
 strategy = "initramfs"
@@ -247,12 +247,12 @@ version = "latest"
 	tmpFile := writeTempConfig(t, content)
 	defer os.Remove(tmpFile)
 
-	_, err := Load(tmpFile)
-	if err == nil {
-		t.Fatal("expected error for missing busybox_url, got nil")
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "busybox_url") {
-		t.Errorf("error should mention 'busybox_url', got: %v", err)
+	if cfg.Source.BusyboxURL == "" {
+		t.Fatalf("expected default busybox_url to be applied")
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -43,6 +43,14 @@ type SourceConfig struct {
 	// For "oci_rootfs" strategy
 	Image string `toml:"image,omitempty"`
 
+	// Optional Dockerfile build inputs (for both strategies)
+	// If Dockerfile is provided, Fledge will build the image locally using the
+	// Docker daemon, then export/overlay it depending on the strategy.
+	Dockerfile string            `toml:"dockerfile,omitempty"`
+	Context    string            `toml:"context,omitempty"`
+	Target     string            `toml:"target,omitempty"`
+	BuildArgs  map[string]string `toml:"build_args,omitempty"`
+
 	// For "initramfs" strategy
 	BusyboxURL    string `toml:"busybox_url,omitempty"`
 	BusyboxSHA256 string `toml:"busybox_sha256,omitempty"`
@@ -80,4 +88,11 @@ const (
 	AgentSourceRelease = "release"
 	AgentSourceLocal   = "local"
 	AgentSourceHTTP    = "http"
+)
+
+// Default Busybox (musl static) used when not provided by user.
+// Users can override via [source] busybox_url and busybox_sha256.
+const (
+	DefaultBusyboxURL    = "https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox"
+	DefaultBusyboxSHA256 = "6e123e7f3202a8c1e9b1f94d8941580a25135382b99e8d3e34fb858bba311348"
 )


### PR DESCRIPTION
…; cleanup ephemeral tags\n\n- Add [source] dockerfile/context/target/build_args\n- oci_rootfs: docker build -> skopeo/umoci, auto-clean ephemeral tag\n- initramfs: overlay built image -> busybox -> kestrel/init -> pack\n- Defaults: pinned musl Busybox when not provided\n- CLI: allow dockerfile path as input for oci_rootfs\n- Docs: README examples for Dockerfile flows